### PR TITLE
fix: clean listeners before adding new ones

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,6 +7,11 @@ export function setListeners(
   onStart = val => {},
   onFinish = val => {}
 ) {
+  emitter.removeAllListeners("onFailure");
+  emitter.removeAllListeners("onSuccess");
+  emitter.removeAllListeners("onProgress");
+  emitter.removeAllListeners("onStart");
+  emitter.removeAllListeners("onFinish");
   emitter.addListener("onFailure", val => onFailure(val));
   emitter.addListener("onSuccess", val => onSuccess(val));
   emitter.addListener("onProgress", val => onProgress(val));


### PR DESCRIPTION
function is called `setListeners` so it basically means it should clean the previous state.